### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/import-secrets.yml
+++ b/.github/workflows/import-secrets.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ inputs.secrets }}
 
       - name: Write to Github
-        uses: google/secrets-sync-action@v1.7.0
+        uses: jpoehnelt/secrets-sync-action@v1.7.0
         with:
           secrets: |
             ^AWS_.*


### PR DESCRIPTION
This is a PR to update the action to the new repository location.\n\nNote GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.